### PR TITLE
refactor: Update messages UI, receivers logic, and translations

### DIFF
--- a/components/messages/message_common_component.js
+++ b/components/messages/message_common_component.js
@@ -30,7 +30,7 @@ const AttachmentWarning = ({ hasAttachment }) => {
  * @returns {JSX.Element} List of receiver badges or a single "missing receiver" badge
  */
 const MessageReceivers = ({ receivers }) => {
-  const { t } = useTranslation(); // Hook to access default translations
+  const { t } = useTranslation("messages"); // Hook to access translations from "messages" namespace
 
   // Check if receivers is not an array or is empty; display "Me" badge
   if (!Array.isArray(receivers) || !receivers.length) {

--- a/pages/[locale]/messages.js
+++ b/pages/[locale]/messages.js
@@ -47,16 +47,14 @@ const MessagesPage = () => {
         />
       ) : (
         <div className="space-y-4">
-          <div className="flex items-center gap-4">
+          <div className="flex flex-col items-start gap-2">
             <h1 className="text-3xl font-semibold">{t("title")}</h1>
-            <div className="flex flex-col">
-              <span className="text-xl font-semibold">
-                {isInbox ? t("inbox") : t("outbox")}
-              </span>
-              <button className="btn btn-primary btn-outline" onClick={toggleMessages}>
-                {isInbox ? t("switch_outbox") : t("switch_inbox")}
-              </button>
-            </div>
+            <span className="text-xl font-semibold">
+              {isInbox ? t("inbox") : t("outbox")}
+            </span>
+            <button className="btn btn-primary btn-outline" onClick={toggleMessages}>
+              {isInbox ? t("switch_outbox") : t("switch_inbox")}
+            </button>
           </div>
 
           {messagesData ? (

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -32,7 +32,6 @@
     "summary": "Summary",
     "school": {
       "semester": "Semester {{semester}}"
-    },
-    "me": "Me"
+    }
   }
 }

--- a/public/locales/en/messages.json
+++ b/public/locales/en/messages.json
@@ -19,5 +19,6 @@
   "unread": "Unread",
   "file_unsupported": "This message has an attachment!",
   "no_messages": "No messages available",
-  "back_button": "Back"
+  "back_button": "Back",
+  "me": "Me"
 }


### PR DESCRIPTION
refactor: Update messages UI, receivers logic, and translations
- Adjusts mailbox header layout, button position, and style:
  Stacks the "Messages" title, mailbox type, and switch button
  vertically. The button is styled with 'btn-primary btn-outline'.
  This improves the UI, especially on narrower screens.

- Adjusts message receivers display due to API change:
  Updates the MessageReceivers component to handle changes in the API
  response where detailed recipient info might be missing.
  The component now checks if the `receivers` array is empty or not an
  array, displaying a "Me" badge.

- Updates `useTranslation` hook in MessageReceivers.