### PR TITLE
feat: Internationalize timetable weekdays

### DIFF
--- a/pages/[locale]/timetable.js
+++ b/pages/[locale]/timetable.js
@@ -25,15 +25,6 @@ const Timetable = () => {
     loading: timetableLoading,
     error: timetableError,
   } = useTimetable(date);
-  const weekDays = [
-    "Monday",
-    "Tuesday",
-    "Wednesday",
-    "Thursday",
-    "Friday",
-    "Saturday",
-    "Sunday",
-  ];
 
   return (
     <Layout>
@@ -75,7 +66,7 @@ const Timetable = () => {
                   key={day}
                 >
                   <span className="text-xl font-semibold">
-                    {weekDays[dayjs(day).isoWeekday() - 1]}
+                    {t(`weekDays.${dayjs(day).isoWeekday() - 1}`)}
                   </span>
                   <div className="flex flex-col gap-2">
                     {dayData.every((x) => x.length == 0) && (

--- a/public/locales/en/timetable.json
+++ b/public/locales/en/timetable.json
@@ -2,5 +2,14 @@
   "title": "Timetable",
   "empty": "No classes",
   "substitution": "Substitution",
-  "canceled": "CANCELED"
+  "canceled": "CANCELED",
+  "weekDays": [
+    "Monday",
+    "Tuesday",
+    "Wednesday",
+    "Thursday",
+    "Friday",
+    "Saturday",
+    "Sunday"
+  ]
 }

--- a/public/locales/pl/timetable.json
+++ b/public/locales/pl/timetable.json
@@ -2,5 +2,14 @@
   "title": "Plan lekcji",
   "empty": "Brak lekcji",
   "substitution": "Zastępstwo",
-  "canceled": "ODWOŁANE"
+  "canceled": "ODWOŁANE",
+  "weekDays": [
+    "Poniedziałek",
+    "Wtorek",
+    "Środa",
+    "Czwartek",
+    "Piątek",
+    "Sobota",
+    "Niedziela"
+  ]
 }


### PR DESCRIPTION
This commit internationalizes the display of weekdays in the timetable component.

- Removes the hardcoded `weekDays` array from `pages/[locale]/timetable.js`.
- Uses the `useTranslation` hook to look up the weekday names based on the current locale.
- Adds English and Polish translations for the weekdays to the respective `timetable.json` locale files.

This makes the timetable component fully translatable and removes hardcoded English strings.