### PR TITLE
feat(messages): Display and download attachments

### DIFF
--- a/components/messages/message_common_component.js
+++ b/components/messages/message_common_component.js
@@ -1,26 +1,4 @@
-import { ExclamationTriangleFill } from "react-bootstrap-icons";
 import { useTranslation } from "react-i18next";
-
-/**
- * AttachmentWarning Component
- * Displays a warning badge when a message has an unsupported attachment.
- * @param {Object} props - Component props
- * @param {boolean} props.hasAttachment - Indicates if there is an attachment
- * @returns {JSX.Element|null} Warning badge or null if no attachment
- */
-const AttachmentWarning = ({ hasAttachment }) => {
-  const { t } = useTranslation("messages");
-
-  // If there’s no attachment, render nothing
-  if (!hasAttachment) return null;
-
-  return (
-    <div className="flex flex-row text-warning gap-2 mt-2 p-1 flex-wrap">
-      <ExclamationTriangleFill className="text-lg" />
-      {t("file_unsupported")}
-    </div>
-  );
-};
 
 /**
  * MessageReceivers Component
@@ -100,5 +78,4 @@ const TagsList = ({ tags, tagsLibrary }) => {
   );
 };
 
-export { TagsList, MessageReceivers, AttachmentWarning };
-export default AttachmentWarning;
+export { TagsList, MessageReceivers };

--- a/components/messages/message_item_view.js
+++ b/components/messages/message_item_view.js
@@ -1,5 +1,5 @@
 import { EnvelopeOpenFill, EnvelopeFill } from "react-bootstrap-icons";
-import { AttachmentWarning, TagsList } from "./message_common_component";
+import { TagsList } from "./message_common_component";
 import { removeCDATA, decodeBase64, formatDate } from "@/lib/utils";
 import { useTranslation } from "react-i18next";
 
@@ -43,7 +43,6 @@ const MessageItem = ({ message, onClick, isInbox, tagsLibrary }) => {
         <div className="text-sm text-base-content/80">
           {removeCDATA(decodeBase64(message.content)) || t("missing.content")}
         </div>
-        <AttachmentWarning hasAttachment={message.isAnyFileAttached} />
       </div>
     </div>
   );

--- a/lib/messages.js
+++ b/lib/messages.js
@@ -8,6 +8,7 @@ const messagesOutboxUrl = `${messagesUrl}/outbox/messages`;
 const messageDetailsInboxUrl = `${messagesUrl}/inbox/messages/`;
 const messageDetailsOutboxUrl = `${messagesUrl}/outbox/messages/`;
 const messageTagsUrl = `${messagesUrl}/tags`;
+const messageAttachmentsUrl = `${messagesUrl}/attachments`;
 
 /**
  * Fetches paginated messages from either inbox or outbox.
@@ -121,7 +122,7 @@ const useMessageDetails = (messageId, isInbox) => {
       try {
         const fetchedData = await getMessageDetails(messageId, isInbox);
         if (!fetchedData) throw new Error("Failed to fetch message data");
-        setData(fetchedData);
+        setData({ ...fetchedData, id: messageId });
         setError(null);
       } catch (err) {
         setError(err.message);
@@ -129,8 +130,9 @@ const useMessageDetails = (messageId, isInbox) => {
         setLoading(false);
       }
     };
-
-    fetchData();
+    if (messageId) {
+      fetchData();
+    }
   }, [messageId, isInbox]);
 
   return { data, loading, error };
@@ -178,10 +180,47 @@ const fetchMessageTags = async () => {
   }
 };
 
+/**
+ * Constructs the API endpoint for fetching an attachment's download URL.
+ * @param {string} attachmentId - The ID of the attachment.
+ * @param {string} messageId - The ID of the message.
+ * @returns {string} The API endpoint for the attachment.
+ */
+const getAttachmentDownloadLink = (attachmentId, messageId) => {
+  return `${messageAttachmentsUrl}/${attachmentId}/messages/${messageId}`;
+};
+
+/**
+ * Fetches the actual download URL for a message attachment.
+ * @param {string} attachmentId - The ID of the attachment.
+ * @param {string} messageId - The ID of the message.
+ * @returns {Promise<string>} A promise that resolves to the download URL.
+ * @throws {Error} If the download link cannot be fetched or is missing.
+ */
+const fetchAttachmentDownloadUrl = async (attachmentId, messageId) => {
+  const url = getAttachmentDownloadLink(attachmentId, messageId);
+  try {
+    const response = await Request.get(url);
+    const downloadLink = response?.downloadLink;
+
+    if (!downloadLink) {
+      throw new Error(`No download link found in the API response. ${JSON.stringify(response)}`);
+    }
+    
+    return downloadLink;
+  } catch (error) {
+    console.error(`Failed to fetch attachment download URL from ${url}:`, error);
+    throw new Error(`Failed to fetch attachment download URL. Attempted to access: ${url}. Original error: ${error.message}`);
+  }
+};
+
+
 export {
   getMessages,
   getMessageDetails,
   useMessages,
   useMessageDetails,
   useMessageTags,
+  getAttachmentDownloadLink,
+  fetchAttachmentDownloadUrl,
 };

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
   "devDependencies": {
     "@capacitor/assets": "^3.0.5",
     "@capacitor/cli": "^7.4.2",
+    "@tailwindcss/line-clamp": "^0.4.4",
     "@tailwindcss/postcss": "^4.1.11",
     "daisyui": "^5.0.50",
     "eslint": "^9.33.0",

--- a/public/locales/pl/messages.json
+++ b/public/locales/pl/messages.json
@@ -17,7 +17,7 @@
   "send": "Wyślij",
   "read": "Przeczytane",
   "unread": "Nieprzeczytane",
-  "file_unsupported": "Ta wiadomość ma załącznik!",
+  "attachments": "Załączniki",
   "no_messages": "Brak wiadomości",
   "back_button": "Wróć",
   "me" : "Mnie"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1708,6 +1708,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@tailwindcss/line-clamp@npm:^0.4.4":
+  version: 0.4.4
+  resolution: "@tailwindcss/line-clamp@npm:0.4.4"
+  peerDependencies:
+    tailwindcss: ">=2.0.0 || >=3.0.0 || >=3.0.0-alpha.1"
+  checksum: 10c0/53e74e75bff066469501b784ab70af444fa460d556a3adf95cb14ccf1a56b1e63c106f0c4bb94463ba0310f2ce1f71350f9b18a556048655cfd2a0ad308ccfb8
+  languageName: node
+  linkType: hard
+
 "@tailwindcss/node@npm:4.1.11":
   version: 4.1.11
   resolution: "@tailwindcss/node@npm:4.1.11"
@@ -5591,6 +5600,7 @@ __metadata:
     "@capacitor/preferences": "npm:^7.0.2"
     "@capawesome-team/capacitor-file-opener": "npm:^7.0.1"
     "@rorygudka/react-infinite-scroller": "npm:^2.0.1"
+    "@tailwindcss/line-clamp": "npm:^0.4.4"
     "@tailwindcss/postcss": "npm:^4.1.11"
     capacitor-secure-storage-plugin: "npm:^0.11.0"
     cordova-plugin-apkupdater: "npm:^5.0.1"


### PR DESCRIPTION
- Replaces the generic attachment warning with a list of downloadable attachment files.
- Updates the message detail view to render attachment information.
- Modifies the data library to handle attachment data.
- Updates Polish translations.
- Removes the unused `AttachmentWarning` component.